### PR TITLE
feat(meta): Add meta viewport for mobile view

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
 
   <meta charset='utf-8'>
   <meta content='IE=edge,chrome=1' http-equiv='X-UA-Compatible'>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <title><%= @page_title.present? ? @page_title : "Git" %></title>
 


### PR DESCRIPTION
## Changes
This PR adds a `meta` tag to ease navigation on mobile

## Context
The website is hard to read on small viewports